### PR TITLE
Allow user to configure sleep alerts

### DIFF
--- a/Telemetry.install
+++ b/Telemetry.install
@@ -1,15 +1,16 @@
 {
-    "name": "Telemetry",
-    "version": "1.2.8",
-    "icon": "fas fa-database",
-    "category": "alice",
-    "author": "ProjectAlice",
-    "maintainers": [
-        "Psychokiller1888",
-        "maxbachmann"
-    ],
-    "desc": "Access your stored telemetry data",
-    "aliceMinVersion": "1.0.0-b3",
+	"name": "Telemetry",
+	"version": "1.3.0",
+	"icon": "fas fa-database",
+	"category": "alice",
+	"author": "ProjectAlice",
+	"maintainers": [
+		"Psychokiller1888",
+		"maxbachmann",
+		"lazza"
+	],
+	"desc": "Access your stored telemetry data",
+	"aliceMinVersion": "1.0.0-b3",
     "pipRequirements": [],
     "systemRequirements": [],
     "conditions": {

--- a/Telemetry.py
+++ b/Telemetry.py
@@ -65,3 +65,17 @@ class Telemetry(AliceSkill):
 			self.endDialog(sessionId=session.sessionId, text=self.randomTalk(text='answerInstant', replace=[answer]))
 		else:
 			self.endDialog(sessionId=session.sessionId, text=self.randomTalk('noData'))
+
+
+	def dontAlertWhenSleeping(self, event: str) -> bool:
+		"""
+		Dont alert the user if they are sleeping unless overriden by the exception list
+		:param event - telemetry event name such as "NoiseAlert"
+		"""
+		if self.UserManager.checkIfAllUser('sleeping'):
+			if event not in self.getConfig('alertWhenSleeping'):
+				return True
+			else:
+				return False
+		else:
+			return False

--- a/config.json.template
+++ b/config.json.template
@@ -70,5 +70,11 @@
 		"dataType": "integer",
 		"isSensitive": false,
 		"description": "UV index at which a high UV alert is broadcasted"
+	},
+	"alertWhenSleeping": {
+		"defaultValue": "GasAlertHigh, CO2AlertHigh",
+		"dataType": "string",
+		"isSensitive": false,
+		"description": "Exclude list to allow being alerted when sleeping"
 	}
 }

--- a/instructions/en.md
+++ b/instructions/en.md
@@ -1,0 +1,31 @@
+# Telemetry skill
+
+## General operation
+
+The telemetry skill recieves your telemtry data from configured sensors and stores those values in the database. When
+this skill recieves new data Alice will alert you if the incoming data exceeds or equals the values you have set in the
+skill settings.
+
+## Configuration
+
+Configuration is simple. Go to the skill settings and adjust the values in the list to your desired alert values
+
+- EG: You want to be alerted if temperature equals or exceeds 40c..
+	- Set "TemperatureAlertHigh" to value of 40
+
+## Exclude list while sleeping
+
+When Alice knows your sleeping (because you've said good night to her) she will not alert you at silly oclock in the
+morning if for example, the humidity reading inside is at the high value.
+
+However you can bypass that and get alerted despite being in sleep mode by adding the event you want alerted to in the "
+alertWhenSleeping" field found in the skill settings
+
+The format is comma seperated strings.
+
+Example:
+
+- TemperatureAlertHigh, CO2AlertHigh, GasAlertHigh
+
+In this above example you will get alerted while sleeping for high readings of Temperature, CO2 and Gas readings but not
+alerted for Humidty, wind, rain etc.


### PR DESCRIPTION
##### Summary

Allow user to define alerts they want sent through regardless if they are in sleep mode or not.
Added instructions folder

To use:
in the skill settings there is a extra field that allows a user to add comma separated strings to allow certain events to be announced despite being asleep. refer instructions for more details. 
Reason for feature:
Prevents user being woken up if for example outside humidity levels exceed the alert setting. However this feature allows user to bypass that if for what ever reason they want/need to be alerted of that event.

default settings will allow dangerous alert notifications such as high gas levels and high co2 levels to be announced during sleep
 

##### What kind of change does this PR introduce?

<!-- Check at least one -->

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring
- [ ] Other, please describe:

##### Does this PR introduce a breaking change?

<!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the path to migrate existing installs to this: -->
###### Migration guide:

<!-- How to migrate from existing Alice's installs -->

##### The PR fulfills these requirements:

- [ ] When resolving/implementing a specific issue, it's referenced in the PR's title (e.g. `fix #xxx` or `implement #xxx`, where "xxx" is the issue number)
- [x] You have tested your changes on the branch you wish to merge
- [x] The changes are working


If adding a **new feature**, the PR's description includes:

- [x] The reason for this new feature to be added
- [x] The use of this new feature
- [ ] If available, a link to an existing feature request ticket


###### Other information:
